### PR TITLE
Prepend `X-Original-To` with destination data

### DIFF
--- a/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -115,7 +115,9 @@ module ActionMailbox
           return nil unless notification['Type'] == 'Notification'
           return nil unless message['notificationType'] == 'Received'
 
-          message['content']
+          message['content'].tap do |raw_email|
+            raw_email.prepend("X-Original-To: ", message.dig('mail', 'destination').first, "\n") if message.dig('mail', 'destination')
+          end
         end
 
         def topic

--- a/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -115,7 +115,17 @@ module ActionMailbox
           return nil unless notification['Type'] == 'Notification'
           return nil unless message['notificationType'] == 'Received'
 
-          message['content']
+          message_content
+        end
+
+        def message_content
+          return message['content'] unless destination
+
+          "X-Original-To: #{destination}\n#{message['content']}"
+        end
+
+        def destination
+          message.dig('mail', 'destination')
         end
 
         def topic

--- a/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -125,7 +125,7 @@ module ActionMailbox
         end
 
         def destination
-          message.dig('mail', 'destination')
+          message.dig('mail', 'destination')&.first
         end
 
         def topic

--- a/lib/action_mailbox_amazon_ingress/rspec/email.rb
+++ b/lib/action_mailbox_amazon_ingress/rspec/email.rb
@@ -3,10 +3,11 @@
 module ActionMailboxAmazonIngress
   module RSpec
     class Email
-      def initialize(authentic: true, topic: 'topic:arn:default', mail: default_mail)
+      def initialize(authentic: true, topic: 'topic:arn:default', mail: default_mail, message_params: {})
         @authentic = authentic
         @topic = topic
         @mail = mail
+        @message_params = message_params
       end
 
       def headers
@@ -21,11 +22,15 @@ module ActionMailboxAmazonIngress
         {
           'Type' => 'Notification',
           'TopicArn' => @topic,
-          'Message' => {
-            'notificationType' => 'Received',
-            'content' => @mail.encoded
-          }.to_json
+          'Message' => message_json
         }
+      end
+
+      def message_json
+        {
+          'notificationType' => 'Received',
+          'content' => @mail.encoded
+        }.merge(@message_params).to_json
       end
 
       def authentic?

--- a/spec/requests/rspec_spec.rb
+++ b/spec/requests/rspec_spec.rb
@@ -52,11 +52,13 @@ RSpec.describe 'rspec' do
 
       it 'extracts recipient email from SNS notification content' do
         amazon_ingress_deliver_email(
-          mail: Mail.new,
-          message_params: { 'mail' => { 'destination' => 'user@example.com' } }
+          mail: Mail.new(to: 'user@example.com'),
+          message_params: { 'mail' => { 'destination' => ['bcc_user@example.com'] } }
         )
 
-        expect(ActionMailbox::InboundEmail.last.mail.recipients).to eql ['user@example.com']
+        expect(ActionMailbox::InboundEmail.last.mail.recipients).to contain_exactly(
+          'user@example.com', 'bcc_user@example.com'
+        )
       end
     end
   end

--- a/spec/requests/rspec_spec.rb
+++ b/spec/requests/rspec_spec.rb
@@ -46,5 +46,18 @@ RSpec.describe 'rspec' do
         expect(response).to have_http_status :unauthorized
       end
     end
+
+    context 'with destination parameter set' do
+      let(:topic) { 'topic:arn:default' }
+
+      it 'extracts recipient email from SNS notification content' do
+        amazon_ingress_deliver_email(
+          mail: Mail.new,
+          message_params: { 'mail' => { 'destination' => 'user@example.com' } }
+        )
+
+        expect(ActionMailbox::InboundEmail.last.mail.recipients).to eql ['user@example.com']
+      end
+    end
   end
 end


### PR DESCRIPTION
Outlook seems to omit the BCC recipient's emails from the `To:` header, therefore it is not possible to easily get the SES email that the message was sent to. 

The solution I found was to extract the recipient from the SNS payload - https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html#mail-object

This solution was inspired by a PR for the ActionMailbox Mailgun integration, which had a similar issue - https://github.com/rails/rails/pull/38738
