### PR TITLE
Handles s3 action w/ additional kms encryption

### DIFF
--- a/action_mailbox_amazon_ingress.gemspec
+++ b/action_mailbox_amazon_ingress.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'aws-sdk-sns', '~> 1.23'
   spec.add_runtime_dependency 'aws-sdk-s3', '~> 1.103'
-  spec.add_dependency 'rails', '~> 6'
+  spec.add_dependency 'rails', '>= 6'
 
   spec.add_development_dependency 'betterp', '~> 0.1.3'
   spec.add_development_dependency 'devpack', '~> 0.2.1'

--- a/action_mailbox_amazon_ingress.gemspec
+++ b/action_mailbox_amazon_ingress.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'aws-sdk-sns', '~> 1.23'
+  spec.add_runtime_dependency 'aws-sdk-s3', '~> 1.103'
   spec.add_dependency 'rails', '~> 6'
 
   spec.add_development_dependency 'betterp', '~> 0.1.3'

--- a/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -141,7 +141,7 @@ module ActionMailbox
           end
 
           Rails.logger.debug{"[action_mailbox_amazon_ingress] S3 object #{key} from bucket #{bucket_name} successfully downloaded"}
-          email_content = s3_object.body.read
+          email_content = s3_object.body.read&.scrub("?")
 
           Rails.logger.debug{"[action_mailbox_amazon_ingress] Deleteing S3 object #{key} from bucket #{bucket_name}"}
           s3_client.delete_object(bucket: bucket_name, key: key)

--- a/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -104,7 +104,6 @@ module ActionMailbox
         def verified?
           verifier.authentic?(@notification.to_json)  
         rescue => e
-          debugger
           Rails.logger.error(e)
           false
         end
@@ -134,7 +133,6 @@ module ActionMailbox
 
           return email_content
         rescue Aws::S3::Errors::ServiceError => e
-          debugger
           Rails.logger.error(e)
           return nil
         end

--- a/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -77,7 +77,7 @@ module ActionMailbox
 
         def confirm_subscription
           return unless notification['Type'] == 'SubscriptionConfirmation'
-          return head :ok if confirmation_response_code&.start_with?('2')
+          return head :ok if confirmation_response_code&.to_s&.start_with?('2')
 
           Rails.logger.error{'SNS subscription confirmation request rejected.'}
           head :unprocessable_entity

--- a/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -111,11 +111,42 @@ module ActionMailbox
           @message ||= JSON.parse(notification['Message'])
         end
 
-        def mail
-          return nil unless notification['Type'] == 'Notification'
-          return nil unless message['notificationType'] == 'Received'
+        def receipt
+          @receipt ||= message['receipt']
+        end
 
-          message['content']
+        def mail
+          return @mail if @mail
+          
+          return nil unless notification['Type'] == 'Notification'
+
+          # the email was stored in S3
+          if receipt.dig("action", "type") == "S3"
+            bucket_name = receipt.dig("action", "bucketName")
+            object_key_prefix = receipt.dig("action", "objectKeyPrefix")
+            object_key = receipt.dig("action", "objectKey")
+            key = [object_key_prefix, object_key].compact_blank.join("/")
+
+            s3 = Aws::S3::Client.new
+            s3_object = s3.get_object(bucket: bucket_name, key: key)
+
+            # if the email was encrypted
+            if kms_cmk_id = JSON.parse(s3_object.metadata['x-amz-matdesc'])['kms_cmk_id']
+              s3_encryption = Aws::S3::EncryptionV2::Client.new(client: s3, kms_key_id: kms_cmk_id, key_wrap_schema: :kms_context, content_encryption_schema: :aes_gcm_no_padding, security_profile: :v2_and_legacy)
+              s3_object = s3_encryption.get_object(bucket: bucket_name, key: key)
+            end
+
+            @mail = s3_object.body.read
+
+            s3.delete_object(bucket: bucket_name, key: key)
+
+            return @mail
+          end
+
+          return nil unless message['notificationType'] == 'Received'
+          
+          @mail = message['content']
+          @mail
         end
 
         def topic

--- a/lib/action_mailbox_amazon_ingress.rb
+++ b/lib/action_mailbox_amazon_ingress.rb
@@ -4,6 +4,7 @@ require 'pathname'
 require 'net/http'
 require 'rails'
 require 'action_mailbox/engine'
+require 'aws-sdk-s3'
 require 'aws-sdk-sns'
 
 require 'action_mailbox_amazon_ingress/engine'


### PR DESCRIPTION
Adds the ability to get the message from S3.

Very large emails can actually get omitted from SNS if they are too large [over 256KB](https://aws.amazon.com/about-aws/whats-new/2013/06/18/amazon-sqs-announces-256KB-large-payloads). There is event a [special library in Java](https://docs.aws.amazon.com/sns/latest/dg/large-message-payloads.html) for playing with large message.

That being said, "easy" the solution is to store the SES email to an S3 bucket, get an SNS message saying its been stored in a bucket, then download the content from the bucket object.

I've added an "opinionated" version of this here. It also supports decrypting via KMS (happens under the hood).

Open to making edits if it needs massaging.