### PR TITLE
allow use of rails 6.1+ including rails 7

### DIFF
--- a/action_mailbox_amazon_ingress.gemspec
+++ b/action_mailbox_amazon_ingress.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'aws-sdk-sns', '~> 1.23'
-  spec.add_dependency 'rails', '~> 6'
+  spec.add_dependency 'rails', '>= 6.1'
 
   spec.add_development_dependency 'betterp', '~> 0.1.3'
   spec.add_development_dependency 'devpack', '~> 0.2.1'


### PR DESCRIPTION
Using rails 7.0.0 (was 6.1.4.1)

better than #7 that it actually allows rails 7, I ran bundle update and it did upgrade to rails 7 and ran `make test` and tests pass

oopsie for the previous PR