### PR TITLE
Depend on actionmailbox only.

### DIFF
--- a/action_mailbox_amazon_ingress.gemspec
+++ b/action_mailbox_amazon_ingress.gemspec
@@ -21,12 +21,10 @@ Gem::Specification.new do |spec|
       f.match(%r{^(test|spec|features)/})
     end
   end
-  spec.bindir        = 'bin'
-  spec.executables   = []
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'aws-sdk-sns', '~> 1.23'
-  spec.add_dependency 'rails', '>= 6.1'
+  spec.add_dependency 'actionmailbox', '>= 6.1'
 
   spec.add_development_dependency 'devpack', '~> 0.3.3'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Only actionmailbox is required for this gem to work.