### PR TITLE
Fix: Allow the usage of Rails 6.0

### DIFF
--- a/action_mailbox_amazon_ingress.gemspec
+++ b/action_mailbox_amazon_ingress.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'aws-sdk-sns', '~> 1.23'
-  spec.add_dependency 'rails', '>= 6.1'
+  spec.add_dependency 'rails', '>= 6.0'
 
   spec.add_development_dependency 'devpack', '~> 0.3.3'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Due to https://github.com/bobf/action_mailbox_amazon_ingress/pull/9, the newest version cannot be installed with rails 6.0

I don't see any changes that hinder the use of this library with rails 6.0, so I updated the gemspec

If there is a reason for disallowing rails 6.0 then feel free to close, thanks!