### PR TITLE
Add missing return

### DIFF
--- a/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -35,7 +35,7 @@ module ActionMailbox
         before_action :verify_authenticity, :validate_topic, :confirm_subscription
 
         def create
-          head :bad_request unless notification.message_content.present?
+          return head :bad_request unless notification.message_content.present?
 
           ActionMailbox::InboundEmail.create_and_extract_message_id!(notification.message_content)
           head :no_content
@@ -44,7 +44,7 @@ module ActionMailbox
         private
 
         def verify_authenticity
-          head :bad_request unless notification.present?
+          return head :bad_request unless notification.present?
           head :unauthorized unless notification.verified?
         end
 


### PR DESCRIPTION
Add missing return to already existing 'head :ok' in controller

to fix
```
TypeError (no implicit conversion of nil into String):

/usr/local/lib/ruby/3.2.0/openssl/digest.rb:42:in `update'
/usr/local/lib/ruby/3.2.0/openssl/digest.rb:42:in `hexdigest'
/usr/local/lib/ruby/3.2.0/openssl/digest.rb:42:in `block (3 levels) in <class:Digest>'
actionmailbox (7.1.5.1) app/models/action_mailbox/inbound_email/message_id.rb:17:in `create_and_extract_message_id!'
action_mailbox_amazon_ingress (0.1.3) app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controll
```
